### PR TITLE
Wrap static ILDDecoder object in function

### DIFF
--- a/include/clupatra_new.h
+++ b/include/clupatra_new.h
@@ -38,7 +38,11 @@ namespace lcio{
   struct ILDDecoder : public CellIDDecoder<TrackerHit>{
     ILDDecoder() :  lcio::CellIDDecoder<TrackerHit>( LCTrackerCellID::encoding_string() ) {} 
   } ;
-  static ILDDecoder ILD_cellID ;
+
+  static const BitField64& ILD_cellID( TrackerHit* th ){
+    static ILDDecoder encoder;
+    return encoder( th );
+  }
 
   struct ILDTrackTypeBit{
     static const int SEGMENT ;


### PR DESCRIPTION
necessary to avoid instantiation at library loading time, which access the encoding_string before it can be modified



BEGINRELEASENOTES
- Wrap static ILDDecoder helper object in function to avoid static initialisation at library loading time

ENDRELEASENOTES