### PR TITLE
mem_fn is in funcional

### DIFF
--- a/src/ClupatraProcessor.cc
+++ b/src/ClupatraProcessor.cc
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <memory>
 #include <float.h>
+#include <functional>
 
 //---- MarlinUtil 
 #include "MarlinCED.h"


### PR DESCRIPTION
`mem_fn` is defined in header `<functional>` fix for #16 